### PR TITLE
fix: correct environment name casing in deployment workflow

### DIFF
--- a/.github/workflows/deloy-twitch-webhooks.yml
+++ b/.github/workflows/deloy-twitch-webhooks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
-    environment: staging
+    environment: Staging
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:

--- a/.github/workflows/deploy-twitch-webhooks.yml
+++ b/.github/workflows/deploy-twitch-webhooks.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - workers/twitch-webhooks/**
+      - .github/workflows/deploy-twitch-webhooks.yml
 
 jobs:
   deploy:


### PR DESCRIPTION
Changed environment from 'staging' to 'Staging' in the Twitch webhooks deployment workflow.